### PR TITLE
Move PendingRewardsSlashed event to IRewardsDistributor to simplify ABIs

### DIFF
--- a/src/RewardsDistributorWorkSubmission.sol
+++ b/src/RewardsDistributorWorkSubmission.sol
@@ -7,8 +7,6 @@ import "./interfaces/IComputeRegistry.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 
-event PendingRewardsSlashed(uint256 indexed poolId, address indexed node, uint256 slashedAmount);
-
 contract RewardsDistributorWorkSubmission is IRewardsDistributor, AccessControlEnumerable {
     bytes32 public constant PRIME_ROLE = keccak256("PRIME_ROLE");
     bytes32 public constant FEDERATOR_ROLE = keccak256("FEDERATOR_ROLE");

--- a/src/interfaces/IRewardsDistributor.sol
+++ b/src/interfaces/IRewardsDistributor.sol
@@ -5,6 +5,8 @@ event RewardRate(uint256 indexed poolId, uint256 rate);
 
 event RewardsClaimed(uint256 indexed poolId, address indexed provider, address indexed nodekey, uint256 reward);
 
+event PendingRewardsSlashed(uint256 indexed poolId, address indexed node, uint256 slashedAmount);
+
 interface IRewardsDistributor {
     function calculateRewards(address node) external view returns (uint256, uint256);
     function claimRewards(address node) external;


### PR DESCRIPTION
This will simplify usage of the RewardsDistributor contracts.