### PR TITLE
Ensure work is submitted on rewards distributor

### DIFF
--- a/script/query.py
+++ b/script/query.py
@@ -178,7 +178,7 @@ class ChainReader:
             "call",
             "--rpc-url", self.rpc_url,
             reward_distributor,
-            "calculateRewards(address)(uint256)",
+            "calculateRewards(address)(uint256,uint256)",
             node_subkey
         ]
         return self._run_cast_command(args)
@@ -338,7 +338,7 @@ def main():
     try:
         result = func(*args.args)
         print(result)
-    except TypeError as e:
+    except TypeError:
         print(f"Error: Invalid number of arguments for command '{args.command}'")
         print(f"Usage: python read_chain.py {args.command} [args...]")
         sys.exit(1)

--- a/src/ComputePool.sol
+++ b/src/ComputePool.sol
@@ -308,7 +308,12 @@ contract ComputePool is IComputePool, AccessControlEnumerable {
 
         IDomainRegistry.Domain memory domainInfo = domainRegistry.get(pools[poolId].domainId);
         IWorkValidation workValidation = IWorkValidation(domainInfo.validationLogic);
-        workValidation.submitWork(pools[poolId].domainId, poolId, provider, node, data);
+        (bool success, uint256 workUnits) = workValidation.submitWork(pools[poolId].domainId, poolId, provider, node, data);
+        
+        if (success) {
+            IRewardsDistributor rewardsDistributor = poolStates[poolId].rewardsDistributor;
+            rewardsDistributor.submitWork(node, workUnits);
+        }
     }
 
     function invalidateWork(uint256 poolId, bytes calldata data)

--- a/src/ComputePool.sol
+++ b/src/ComputePool.sol
@@ -308,8 +308,9 @@ contract ComputePool is IComputePool, AccessControlEnumerable {
 
         IDomainRegistry.Domain memory domainInfo = domainRegistry.get(pools[poolId].domainId);
         IWorkValidation workValidation = IWorkValidation(domainInfo.validationLogic);
-        (bool success, uint256 workUnits) = workValidation.submitWork(pools[poolId].domainId, poolId, provider, node, data);
-        
+        (bool success, uint256 workUnits) =
+            workValidation.submitWork(pools[poolId].domainId, poolId, provider, node, data);
+
         if (success) {
             IRewardsDistributor rewardsDistributor = poolStates[poolId].rewardsDistributor;
             rewardsDistributor.submitWork(node, workUnits);

--- a/src/SyntheticDataWorkValidator.sol
+++ b/src/SyntheticDataWorkValidator.sol
@@ -39,7 +39,7 @@ contract SyntheticDataWorkValidator is IWorkValidation {
 
     function submitWork(uint256 _domainId, uint256 poolId, address provider, address nodeId, bytes calldata data)
         external
-        returns (bool)
+        returns (bool, uint256)
     {
         require(msg.sender == computePool, "Unauthorized");
         require(data.length >= 64, "Data too short");
@@ -59,7 +59,7 @@ contract SyntheticDataWorkValidator is IWorkValidation {
 
         emit WorkSubmitted(poolId, provider, nodeId, workKey, workUnits);
 
-        return true;
+        return (true, workUnits);
     }
 
     function invalidateWork(uint256 poolId, bytes calldata data) external returns (address, address) {

--- a/src/interfaces/IWorkValidation.sol
+++ b/src/interfaces/IWorkValidation.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 interface IWorkValidation {
     function submitWork(uint256 _domainId, uint256 poolId, address provider, address nodeId, bytes calldata data)
         external
-        returns (bool);
+        returns (bool, uint256);
 
     function invalidateWork(uint256 poolId, bytes calldata data) external returns (address, address);
 }

--- a/test/SyntheticDataWorkValidator.t.sol
+++ b/test/SyntheticDataWorkValidator.t.sol
@@ -26,8 +26,9 @@ contract SyntheticDataWorkValidatorTest is Test {
         bytes memory data = abi.encodePacked(workKey, workUnits);
 
         vm.warp(42);
-        bool success = validator.submitWork(DOMAIN_ID, POOL_ID, provider, nodeId, data);
+        (bool success, uint256 workUnitsSubmitted) = validator.submitWork(DOMAIN_ID, POOL_ID, provider, nodeId, data);
         assertTrue(success, "Work submission should succeed");
+        assertEq(workUnitsSubmitted, workUnits, "Work units should match");
 
         bytes32[] memory workKeys = validator.getWorkKeys(POOL_ID);
         assertEq(workKeys.length, 1, "Should have one work key");


### PR DESCRIPTION
The compute pool wasn't calling `submitWork` on the rewards distributor contract, resulting in the rewards to not increment.