### PR TITLE
PRI-1212: Remove logic to blacklist providers once they've been slashed

### DIFF
--- a/src/PrimeNetwork.sol
+++ b/src/PrimeNetwork.sol
@@ -182,13 +182,12 @@ contract PrimeNetwork is AccessControlEnumerable {
     function slash(address provider, uint256 amount, bytes calldata reason) external onlyRole(VALIDATOR_ROLE) {
         uint256 slashed = stakeManager.slash(provider, amount, reason);
         AIToken.transfer(msg.sender, slashed);
-        _blacklistIfStakeTooLow(provider);
     }
 
     function invalidateWork(uint256 poolId, uint256 penalty, bytes calldata data) external onlyRole(VALIDATOR_ROLE) {
         (address provider, address node) = computePool.invalidateWork(poolId, data);
         try stakeManager.slash(provider, penalty, data) {
-            _blacklistIfStakeTooLow(provider);
+            // if slashing succeeded, do nothing
         } catch {
             // if slashing failed for whatever reason, blacklist provider to make sure they can't submit more work
             computeRegistry.setWhitelistStatus(provider, false);

--- a/src/PrimeNetwork.sol
+++ b/src/PrimeNetwork.sol
@@ -186,8 +186,8 @@ contract PrimeNetwork is AccessControlEnumerable {
 
     function invalidateWork(uint256 poolId, uint256 penalty, bytes calldata data) external onlyRole(VALIDATOR_ROLE) {
         (address provider, address node) = computePool.invalidateWork(poolId, data);
-        try stakeManager.slash(provider, penalty, data) {
-            AIToken.transfer(msg.sender, penalty);
+        try stakeManager.slash(provider, penalty, data) returns (uint256 slashedAmount) {
+            AIToken.transfer(msg.sender, slashedAmount);
         } catch {
             // if slashing failed for whatever reason, blacklist provider to make sure they can't submit more work
             computeRegistry.setWhitelistStatus(provider, false);

--- a/src/PrimeNetwork.sol
+++ b/src/PrimeNetwork.sol
@@ -187,7 +187,7 @@ contract PrimeNetwork is AccessControlEnumerable {
     function invalidateWork(uint256 poolId, uint256 penalty, bytes calldata data) external onlyRole(VALIDATOR_ROLE) {
         (address provider, address node) = computePool.invalidateWork(poolId, data);
         try stakeManager.slash(provider, penalty, data) {
-            // if slashing succeeded, do nothing
+            AIToken.transfer(msg.sender, penalty);
         } catch {
             // if slashing failed for whatever reason, blacklist provider to make sure they can't submit more work
             computeRegistry.setWhitelistStatus(provider, false);

--- a/test/PrimeNetwork.t.sol
+++ b/test/PrimeNetwork.t.sol
@@ -739,7 +739,7 @@ contract PrimeNetworkTest is Test {
         assertEq(AI.balanceOf(provider_good1), startingBalance);
     }
 
-    function test_stakeBlacklisting() public {
+    function test_stakeSlashing() public {
         uint256 domain = newDomain("Decentralized Training", "https://primeintellect.ai/training/params");
         uint256 pool = newPool(domain, "INTELLECT-1", "https://primeintellect.ai/pools/intellect-1");
 
@@ -779,9 +779,6 @@ contract PrimeNetworkTest is Test {
 
         // check that stake has been slashed to 0
         assertEq(stakeManager.getStake(provider_good1), 0);
-
-        // check that provider is now blacklisted
-        assertEq(computeRegistry.getProvider(provider_good1).isWhitelisted, false);
 
         // check that provider is not allowed to add new nodes to the pool
         vm.expectRevert();


### PR DESCRIPTION
Currently, when a provider gets blacklisted, the orchestrator kicks out all of their nodes. Since we don't want a provider getting all their nodes kicked out because of a slash, I removed the logic that auto-blacklists after a slash.