### PR TITLE
specify solc version in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ libs = ["lib"]
 optimizer = true
 optimizer_runs = 10000000
 fs_permissions = [{ access = "read-write", path = "./release/"}]
-solc_version = "0.8.30"
+solc_version = "0.8.28"
 
 additional_compiler_profiles = [ 
 	{ name = "general", via_ir = true, optimizer_runs = 1000000 },


### PR DESCRIPTION
i was not able to compile the contracts with default foundry (which was using 0.8.21) due to the events being defined outside the contracts. it needed a newer version of solidity.